### PR TITLE
fix XML malformato in ClientDocument

### DIFF
--- a/generators/clientdoc/index.js
+++ b/generators/clientdoc/index.js
@@ -78,7 +78,7 @@ module.exports = class extends Generator {
             return utils.insertInSource(
                 contents.toString(), [{
                     textToInsert: '\t<ServerDocument namespace="'+ this.properties.serverDocNSpace  + '" >\n' +
-                                  '\t\t<ClientDocument namespace="' + this.properties.appName + '.' + this.properties.moduleName + '.' + this.properties.libraryName + '.' + this.properties.clientDocName + '" localize="' + this.properties.clientDocDescription + '" >\n' +
+                                  '\t\t<ClientDocument namespace="' + this.properties.appName + '.' + this.properties.moduleName + '.' + this.properties.libraryName + '.' + this.properties.clientDocName + '" localize="' + this.properties.clientDocDescription + '" />\n' +
                                   '\t</ServerDocument>\n',
                     justBefore: '</ClientDocuments>'
                 }],


### PR DESCRIPTION
Mentre facevo dei test ho scoperto questo problema, in presenza di altir verticali questo errore sull'XML crea degli errori difficilmente riconoscibili